### PR TITLE
Example: IpfsDHT

### DIFF
--- a/examples/connect/findpeer.go
+++ b/examples/connect/findpeer.go
@@ -78,9 +78,6 @@ func FindPeer(ctx context.Context) {
 
 	// create a find peer request message
 	req := ipfsv1.FindPeerRequest(targetID)
-	// empty response message to be filled by the query process, the protobuf
-	// message must be know to parse the response
-	var resp message.ProtoKadResponseMessage = &ipfsv1.Message{}
 	// add friend to routing table
 	success, err := rt.AddPeer(ctx, friendID)
 	if err != nil || !success {
@@ -121,15 +118,22 @@ func FindPeer(ctx context.Context) {
 		return endCond, peers
 	}
 
-	// create the query, using the target kademlia key as target, the IPFS DHT
-	// protocol ID, the request and response messages in the IPFS DHT format,
+	// create the query, the IPFS DHT protocol ID, the IPFS DHT request message,
 	// a concurrency parameter of 1, a timeout of 5 seconds, the libp2p message
 	// endpoint, the node's routing table and scheduler, and the response
 	// handler function.
 	// The query will be executed only once actions are run on the scheduler.
 	// For now, it is only scheduled to be run.
-	simplequery.NewSimpleQuery(ctx, targetID.Key(), protocolID, req, resp, 1,
-		5*time.Second, msgEndpoint, rt, sched, handleResultsFn)
+	queryOpts := []simplequery.Option{
+		simplequery.WithProtocolID(protocolID),
+		simplequery.WithConcurrency(1),
+		simplequery.WithRequestTimeout(5 * time.Second),
+		simplequery.WithHandleResultsFunc(handleResultsFn),
+		simplequery.WithRoutingTable(rt),
+		simplequery.WithEndpoint(msgEndpoint),
+		simplequery.WithScheduler(sched),
+	}
+	simplequery.NewSimpleQuery(ctx, req, queryOpts...)
 
 	span.AddEvent("start request execution")
 

--- a/examples/dispatchquery/main.go
+++ b/examples/dispatchquery/main.go
@@ -111,7 +111,6 @@ func queryTest(ctx context.Context) {
 	_, bin, _ := multibase.Decode(targetBytesID)
 	target := peerid.NewPeerID(peer.ID(bin))
 	req := ipfsv1.FindPeerRequest(target)
-	resp := &ipfsv1.Message{}
 
 	// dummy parameters
 	handleResp := func(ctx context.Context, _ address.NodeID,
@@ -123,8 +122,17 @@ func queryTest(ctx context.Context) {
 		}
 		return false, peerids
 	}
-	sq.NewSimpleQuery(ctx, target.Key(), protoID, req, resp, 1, time.Second, endpointA,
-		rtA, schedA, handleResp)
+
+	queryOpts := []sq.Option{
+		sq.WithProtocolID(protoID),
+		sq.WithConcurrency(1),
+		sq.WithRequestTimeout(5 * time.Second),
+		sq.WithHandleResultsFunc(handleResp),
+		sq.WithRoutingTable(rtA),
+		sq.WithEndpoint(endpointA),
+		sq.WithScheduler(schedA),
+	}
+	sq.NewSimpleQuery(ctx, req, queryOpts...)
 
 	// create simulator
 	sim := litesimulator.NewLiteSimulator(clk)

--- a/examples/fullsim/findnode.go
+++ b/examples/fullsim/findnode.go
@@ -125,7 +125,7 @@ func findNode(ctx context.Context) {
 	queryOpts := []sq.Option{
 		sq.WithProtocolID(protoID),
 		sq.WithConcurrency(1),
-		sq.WithRequestTimeout(5 * time.Second),
+		sq.WithRequestTimeout(time.Second),
 		sq.WithHandleResultsFunc(handleResFn),
 		sq.WithRoutingTable(rts[0]),
 		sq.WithEndpoint(eps[0]),

--- a/examples/ipfsdht/README.md
+++ b/examples/ipfsdht/README.md
@@ -1,0 +1,3 @@
+# `IpfsDHT`
+
+ This `IpfsDHT` example has been made during a live demo. It is far from complete yet, and needs more attention if it is meant to stay. It contains the code to build the `IpfsDHT` object, and perform the IPFS/libp2p `FIND_PEER` RPC.

--- a/examples/ipfsdht/dht.go
+++ b/examples/ipfsdht/dht.go
@@ -1,0 +1,87 @@
+package ipfsdht
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/plprobelab/go-kademlia/events/scheduler/simplescheduler"
+	"github.com/plprobelab/go-kademlia/network/address/addrinfo"
+	"github.com/plprobelab/go-kademlia/network/address/peerid"
+	"github.com/plprobelab/go-kademlia/network/endpoint/libp2pendpoint"
+	sq "github.com/plprobelab/go-kademlia/query/simplequery"
+	"github.com/plprobelab/go-kademlia/routingtable/simplert"
+)
+
+type IpfsDHT struct {
+	pid   *peerid.PeerID
+	rt    *simplert.SimpleRT
+	ep    *libp2pendpoint.Libp2pEndpoint
+	sched *simplescheduler.SimpleScheduler
+
+	queryOpts []sq.Option
+
+	lk                     sync.Mutex
+	ongoingFindPeerQueries map[*peerid.PeerID]*sq.SimpleQuery
+}
+
+func New(ctx context.Context, h host.Host) *IpfsDHT {
+	clk := clock.New()
+	sched := simplescheduler.NewSimpleScheduler(clk)
+
+	pid := peerid.NewPeerID(h.ID())
+	rt := simplert.NewSimpleRT(pid.Key(), 20)
+	ep := libp2pendpoint.NewLibp2pEndpoint(ctx, h, sched)
+
+	queryOpts := []sq.Option{
+		sq.WithProtocolID("/ipfs/kad/1.0.0"),
+		sq.WithConcurrency(10),
+		sq.WithNumberUsefulCloserPeers(20),
+		sq.WithRequestTimeout(time.Second),
+		sq.WithRoutingTable(rt),
+		sq.WithEndpoint(ep),
+		sq.WithScheduler(sched),
+	}
+
+	dht := &IpfsDHT{
+		pid:   pid,
+		rt:    rt,
+		ep:    ep,
+		sched: sched,
+
+		queryOpts: queryOpts,
+
+		lk:                     sync.Mutex{},
+		ongoingFindPeerQueries: make(map[*peerid.PeerID]*sq.SimpleQuery),
+	}
+
+	dht.Run(ctx)
+
+	return dht
+}
+
+func (dht *IpfsDHT) Connect(ctx context.Context, ai peer.AddrInfo) {
+	addr := addrinfo.NewAddrInfo(ai)
+	dht.ep.MaybeAddToPeerstore(ctx, addr, 30*time.Minute)
+	dht.rt.AddPeer(ctx, addr.PeerID())
+}
+
+func (dht *IpfsDHT) Run(ctx context.Context) {
+	go func() {
+		for {
+			for dht.sched.RunOne(ctx) {
+			}
+			time.Sleep(time.Millisecond * 100)
+		}
+	}()
+}
+
+func (dht *IpfsDHT) OngoingQueries() int {
+	dht.lk.Lock()
+	defer dht.lk.Unlock()
+
+	return len(dht.ongoingFindPeerQueries)
+}

--- a/examples/ipfsdht/findpeer.go
+++ b/examples/ipfsdht/findpeer.go
@@ -1,0 +1,90 @@
+package ipfsdht
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/plprobelab/go-kademlia/network/address"
+	"github.com/plprobelab/go-kademlia/network/address/addrinfo"
+	"github.com/plprobelab/go-kademlia/network/address/peerid"
+	"github.com/plprobelab/go-kademlia/network/message"
+	"github.com/plprobelab/go-kademlia/network/message/ipfsv1"
+	"github.com/plprobelab/go-kademlia/query/simplequery"
+)
+
+func (dht *IpfsDHT) FindPeer(ctx context.Context, p peer.ID) (peer.AddrInfo, error) {
+
+	pid := peerid.NewPeerID(p)
+	req := ipfsv1.FindPeerRequest(pid)
+
+	resChan := make(chan *peer.AddrInfo, 1)
+
+	var stopQuery bool
+
+	dialResponseHandler := func(ctx context.Context, success bool) {
+		if success {
+			na, err := dht.ep.NetworkAddress(pid)
+			if err != nil {
+				return
+			}
+			ai, ok := na.(*addrinfo.AddrInfo)
+			if !ok {
+				panic("invalid network address type")
+			}
+			stopQuery = true
+			resChan <- &ai.AddrInfo
+		}
+	}
+
+	responseHandler := func(ctx context.Context, id address.NodeID,
+		resp message.MinKadResponseMessage) (bool, []address.NodeID) {
+		// parse response to ipfs dht message
+		msg, ok := resp.(*ipfsv1.Message)
+		if !ok {
+			fmt.Println("invalid response!")
+			return false, nil
+		}
+		peers := make([]address.NodeID, 0, len(msg.CloserPeers))
+		for _, p := range msg.CloserPeers {
+			addrInfo, err := ipfsv1.PBPeerToPeerInfo(p)
+			if err != nil {
+				fmt.Println("invalid peer info format")
+				continue
+			}
+			peers = append(peers, addrInfo.PeerID())
+			if addrInfo.PeerID().ID == pid.ID {
+				resChan <- &addrInfo.AddrInfo
+
+				dht.ep.AsyncDialAndReport(ctx, pid, dialResponseHandler)
+				return true, nil
+			}
+		}
+		return stopQuery, peers
+	}
+
+	dht.lk.Lock()
+	dht.ongoingFindPeerQueries[pid] = simplequery.NewSimpleQuery(ctx, req,
+		append(dht.queryOpts, simplequery.WithHandleResultsFunc(responseHandler))...)
+	dht.lk.Unlock()
+
+	// wait for query to finish
+	select {
+	case <-ctx.Done():
+		dht.lk.Lock()
+		delete(dht.ongoingFindPeerQueries, pid)
+		dht.lk.Unlock()
+
+		return peer.AddrInfo{}, ctx.Err()
+	case res := <-resChan:
+		dht.lk.Lock()
+		delete(dht.ongoingFindPeerQueries, pid)
+		dht.lk.Unlock()
+
+		if res == nil {
+			return peer.AddrInfo{}, fmt.Errorf("peer %s not found", p)
+		}
+		return *res, nil
+	}
+
+}

--- a/examples/ipfsdht/test/main.go
+++ b/examples/ipfsdht/test/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/plprobelab/go-kademlia/examples/ipfsdht"
+	"github.com/plprobelab/go-kademlia/util"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+func findPeer(ctx context.Context) {
+	ctx, span := util.StartSpan(ctx, "findPeer")
+	defer span.End()
+
+	h, err := libp2p.New()
+	if err != nil {
+		panic(err)
+	}
+	dht := ipfsdht.New(ctx, h)
+	dht.Connect(ctx, bootstrapPeer())
+
+	target, err := peer.Decode("QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb")
+	if err != nil {
+		panic(err)
+	}
+
+	ai, err := dht.FindPeer(ctx, target)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Println("found peer:", ai)
+}
+
+func bootstrapPeer() peer.AddrInfo {
+	// friend is the first peer we know in the IPFS DHT network (bootstrap node)
+	friend, err := peer.Decode("12D3KooWGjgvfDkpuVAoNhd7PRRvMTEG4ZgzHBFURqDe1mqEzAMS")
+	if err != nil {
+		panic(err)
+	}
+
+	// multiaddress of friend
+	a, err := multiaddr.NewMultiaddr("/ip4/45.32.75.236/udp/4001/quic")
+	if err != nil {
+		panic(err)
+	}
+	// connect to friend
+	return peer.AddrInfo{ID: friend, Addrs: []multiaddr.Multiaddr{a}}
+}
+
+func main() {
+	tp, err := tracerProvider("http://localhost:14268/api/traces")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Register our TracerProvider as the global so any imported
+	// instrumentation in the future will default to using it.
+	otel.SetTracerProvider(tp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cleanly shutdown and flush telemetry when the application exits.
+	defer func(ctx context.Context) {
+		// Do not make the application hang when it is shutdown.
+		ctx, cancel = context.WithTimeout(ctx, time.Second*5)
+		defer cancel()
+		if err := tp.Shutdown(ctx); err != nil {
+			log.Fatal(err)
+		}
+	}(ctx)
+
+	findPeer(ctx)
+}
+
+// tracerProvider returns an OpenTelemetry TracerProvider configured to use
+// the Jaeger exporter that will send spans to the provided url. The returned
+// TracerProvider will also use a Resource configured with all the information
+// about the application.
+func tracerProvider(url string) (*trace.TracerProvider, error) {
+	// Create the Jaeger exporter
+	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
+	if err != nil {
+		return nil, err
+	}
+	tp := trace.NewTracerProvider(
+		// Always be sure to batch in production.
+		trace.WithBatcher(exp),
+		// Record information about this application in a Resource.
+		trace.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName("Kademlia-Test"),
+			semconv.ServiceVersion("v0.1.0"),
+			attribute.String("environment", "demo"),
+		)),
+	)
+	return tp, nil
+}

--- a/network/endpoint/endpoint.go
+++ b/network/endpoint/endpoint.go
@@ -40,7 +40,7 @@ type Endpoint interface {
 type ServerEndpoint interface {
 	Endpoint
 	// AddRequestHandler registers a handler for a given protocol ID.
-	AddRequestHandler(address.ProtocolID, RequestHandlerFn, message.MinKadMessage) error
+	AddRequestHandler(address.ProtocolID, message.MinKadMessage, RequestHandlerFn) error
 	// RemoveRequestHandler removes a handler for a given protocol ID.
 	RemoveRequestHandler(address.ProtocolID)
 }

--- a/network/endpoint/fakeendpoint/fakeendpoint.go
+++ b/network/endpoint/fakeendpoint/fakeendpoint.go
@@ -206,7 +206,7 @@ func (e *FakeEndpoint) HandleMessage(ctx context.Context, id address.NodeID,
 }
 
 func (e *FakeEndpoint) AddRequestHandler(protoID address.ProtocolID,
-	reqHandler endpoint.RequestHandlerFn, req message.MinKadMessage) error {
+	req message.MinKadMessage, reqHandler endpoint.RequestHandlerFn) error {
 	e.serverProtos[protoID] = reqHandler
 	return nil
 }

--- a/network/endpoint/fakeendpoint/fakeendpoint_test.go
+++ b/network/endpoint/fakeendpoint/fakeendpoint_test.go
@@ -78,7 +78,7 @@ func TestFakeEndpoint(t *testing.T) {
 	fakeEndpoint0 := NewFakeEndpoint(node0, sched0, router)
 	rt0 := simplert.NewSimpleRT(node0.Key(), 2)
 	serv0 := basicserver.NewBasicServer(rt0, fakeEndpoint0)
-	fakeEndpoint0.AddRequestHandler(protoID, serv0.HandleRequest, nil)
+	fakeEndpoint0.AddRequestHandler(protoID, nil, serv0.HandleRequest)
 	// remove a request handler that doesn't exist
 	fakeEndpoint0.RemoveRequestHandler("/test/0.0.1")
 
@@ -118,7 +118,7 @@ func TestFakeEndpoint(t *testing.T) {
 		return nil, endpoint.ErrUnknownPeer
 	}
 	errProtoID := address.ProtocolID("/err/0.0.1")
-	fakeEndpoint.AddRequestHandler(errProtoID, errHandler, nil)
+	fakeEndpoint.AddRequestHandler(errProtoID, nil, errHandler)
 	fakeEndpoint.HandleMessage(ctx, node0, errProtoID, 1001, msg)
 	// no message should have been sent to node0, so nothing to run
 	require.False(t, sched0.RunOne(ctx))
@@ -154,7 +154,7 @@ func TestRequestTimeout(t *testing.T) {
 		req message.MinKadMessage) (message.MinKadMessage, error) {
 		return nil, endpoint.ErrUnknownPeer
 	}
-	fakeEndpoints[1].AddRequestHandler(protoID, dropRequestHandler, nil)
+	fakeEndpoints[1].AddRequestHandler(protoID, nil, dropRequestHandler)
 	// fakeEndpoints[0] will send a request to fakeEndpoints[1], but the request
 	// will timeout (because fakeEndpoints[1] will not respond)
 	fakeEndpoints[0].SendRequestHandleResponse(ctx, protoID, ids[1], nil, nil,
@@ -201,7 +201,7 @@ func TestRequestTimeout(t *testing.T) {
 	// create valid message
 	msg := simmessage.NewSimResponse(make([]address.NodeID, 0))
 	// overwrite request handler
-	fakeEndpoints[1].AddRequestHandler(protoID, dumbResponseHandler, nil)
+	fakeEndpoints[1].AddRequestHandler(protoID, nil, dumbResponseHandler)
 	fakeEndpoints[0].SendRequestHandleResponse(ctx, protoID, ids[1], msg, nil,
 		time.Second, func(ctx context.Context,
 			msg message.MinKadResponseMessage, err error) {

--- a/network/endpoint/libp2pendpoint/libp2pendpoint.go
+++ b/network/endpoint/libp2pendpoint/libp2pendpoint.go
@@ -268,7 +268,7 @@ func (e *Libp2pEndpoint) NetworkAddress(n address.NodeID) (address.NodeID, error
 }
 
 func (e *Libp2pEndpoint) AddRequestHandler(protoID address.ProtocolID,
-	reqHandler endpoint.RequestHandlerFn, req message.MinKadMessage) error {
+	req message.MinKadMessage, reqHandler endpoint.RequestHandlerFn) error {
 
 	protoReq, ok := req.(message.ProtoKadMessage)
 	if !ok {

--- a/network/endpoint/libp2pendpoint/libp2pendpoint_test.go
+++ b/network/endpoint/libp2pendpoint/libp2pendpoint_test.go
@@ -166,7 +166,7 @@ func TestLibp2pEndpoint(t *testing.T) {
 		// request handler returning the received message
 		return req, nil
 	}
-	err = endpoints[1].AddRequestHandler(protoID, requestHandler, &ipfsv1.Message{})
+	err = endpoints[1].AddRequestHandler(protoID, &ipfsv1.Message{}, requestHandler)
 	require.NoError(t, err)
 
 	// send request from 0 to 1
@@ -226,12 +226,12 @@ func TestLibp2pEndpoint(t *testing.T) {
 	wg.Wait()
 
 	// test timeout
-	err = endpoints[1].AddRequestHandler(protoID, func(ctx context.Context,
+	err = endpoints[1].AddRequestHandler(protoID, &ipfsv1.Message{}, func(ctx context.Context,
 		id address.NodeID, req message.MinKadMessage) (message.MinKadMessage, error) {
 		// request handler wait 2ms before returning the received message
 		time.Sleep(10 * time.Millisecond)
 		return req, nil
-	}, &ipfsv1.Message{})
+	})
 	require.NoError(t, err)
 	wg.Add(1)
 	// timeout after 1 ms
@@ -253,11 +253,11 @@ func TestLibp2pEndpoint(t *testing.T) {
 	require.False(t, scheds[1].RunOne(ctx))
 
 	// server request handler error
-	err = endpoints[1].AddRequestHandler(protoID, func(ctx context.Context,
+	err = endpoints[1].AddRequestHandler(protoID, &ipfsv1.Message{}, func(ctx context.Context,
 		id address.NodeID, req message.MinKadMessage) (message.MinKadMessage, error) {
 		// request handler returns error
 		return nil, errors.New("server error")
-	}, &ipfsv1.Message{})
+	})
 	require.NoError(t, err)
 	err = endpoints[0].SendRequestHandleResponse(ctx, protoID, ids[1], req,
 		resp, 0, responseHandler)
@@ -271,11 +271,11 @@ func TestLibp2pEndpoint(t *testing.T) {
 	require.False(t, scheds[0].RunOne(ctx))
 
 	// server request handler returns wrong message type
-	err = endpoints[1].AddRequestHandler(protoID, func(ctx context.Context,
+	err = endpoints[1].AddRequestHandler(protoID, &ipfsv1.Message{}, func(ctx context.Context,
 		id address.NodeID, req message.MinKadMessage) (message.MinKadMessage, error) {
 		// request handler returns error
 		return &simmessage.SimMessage{}, nil
-	}, &ipfsv1.Message{})
+	})
 	require.NoError(t, err)
 	err = endpoints[0].SendRequestHandleResponse(ctx, protoID, ids[1], req,
 		resp, 0, responseHandler)
@@ -289,7 +289,7 @@ func TestLibp2pEndpoint(t *testing.T) {
 	require.False(t, scheds[0].RunOne(ctx))
 
 	// invalid message format for handler
-	err = endpoints[0].AddRequestHandler("/fail/1.0.0", requestHandler, &simmessage.SimMessage{})
+	err = endpoints[0].AddRequestHandler("/fail/1.0.0", &simmessage.SimMessage{}, requestHandler)
 	require.Equal(t, ErrRequireProtoKadMessage, err)
 
 	// remove request handler

--- a/network/message/ipfsv1/helpers.go
+++ b/network/message/ipfsv1/helpers.go
@@ -18,6 +18,7 @@ var (
 	ErrNoValidAddresses = errors.New("no valid addresses")
 )
 
+var _ message.ProtoKadRequestMessage = (*Message)(nil)
 var _ message.ProtoKadResponseMessage = (*Message)(nil)
 
 func FindPeerRequest(p *peerid.PeerID) *Message {
@@ -41,6 +42,10 @@ func (msg *Message) Target() key.KadKey {
 		return nil
 	}
 	return peerid.PeerID{ID: p}.Key()
+}
+
+func (msg *Message) EmptyResponse() message.MinKadResponseMessage {
+	return &Message{}
 }
 
 func (msg *Message) CloserNodes() []address.NodeID {

--- a/network/message/ipfsv1/helpers_test.go
+++ b/network/message/ipfsv1/helpers_test.go
@@ -78,6 +78,8 @@ func TestCornerCases(t *testing.T) {
 	require.Nil(t, resp.Target())
 	require.Equal(t, 0, len(resp.CloserNodes()))
 
+	require.Equal(t, &Message{}, resp.EmptyResponse())
+
 	ids := make([]address.NodeID, 0)
 	resp = FindPeerResponse(ids, nil)
 

--- a/network/message/message.go
+++ b/network/message/message.go
@@ -12,7 +12,8 @@ type MinKadMessage interface {
 type MinKadRequestMessage interface {
 	MinKadMessage
 
-	Target() *key.KadKey
+	Target() key.KadKey
+	EmptyResponse() MinKadResponseMessage
 }
 
 type MinKadResponseMessage interface {

--- a/network/message/simmessage/simmessage.go
+++ b/network/message/simmessage/simmessage.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SimMessage struct {
-	target      *key.KadKey
+	target      key.KadKey
 	closerPeers []address.NodeID
 }
 
@@ -16,7 +16,7 @@ var _ message.MinKadResponseMessage = (*SimMessage)(nil)
 
 func NewSimRequest(target key.KadKey) *SimMessage {
 	return &SimMessage{
-		target: &target,
+		target: target,
 	}
 }
 
@@ -26,8 +26,12 @@ func NewSimResponse(closerPeers []address.NodeID) *SimMessage {
 	}
 }
 
-func (m *SimMessage) Target() *key.KadKey {
+func (m *SimMessage) Target() key.KadKey {
 	return m.target
+}
+
+func (m *SimMessage) EmptyResponse() message.MinKadResponseMessage {
+	return &SimMessage{}
 }
 
 func (m *SimMessage) CloserNodes() []address.NodeID {

--- a/network/message/simmessage/simmessage_test.go
+++ b/network/message/simmessage/simmessage_test.go
@@ -15,6 +15,8 @@ func TestSimRequest(t *testing.T) {
 	reqTarget := msg.Target()
 	require.NotNil(t, reqTarget)
 
+	require.Equal(t, &SimMessage{}, msg.EmptyResponse())
+
 	b, _ := msg.Target().Equal(target.Key())
 	require.True(t, b)
 	require.Nil(t, msg.CloserNodes())

--- a/query/simplequery/options.go
+++ b/query/simplequery/options.go
@@ -1,0 +1,165 @@
+package simplequery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/plprobelab/go-kademlia/events/scheduler"
+	"github.com/plprobelab/go-kademlia/network/address"
+	"github.com/plprobelab/go-kademlia/network/endpoint"
+	"github.com/plprobelab/go-kademlia/network/message"
+	"github.com/plprobelab/go-kademlia/routingtable"
+)
+
+// Config is a structure containing all the options that can be used when
+// constructing a SimpleQuery.
+type Config struct {
+	// ProtocolID is the protocol identifier used to send the request
+	ProtocolID address.ProtocolID
+	// NumberUsefulCloserPeers is the number of closer peers to look for in the
+	// provided routing table when starting the request
+	NumberUsefulCloserPeers int
+	// Concurrency is the maximal number of simultaneous inflight requests for
+	// this query
+	Concurrency int
+
+	// RequestTimeout is the timeout value for a single request
+	RequestTimeout time.Duration
+	// PeerstoreTTL is the TTL value for newly discovered peers in the peerstore
+	PeerstoreTTL time.Duration
+
+	// HandleResultFn is a function that is called when a response is received
+	// for a request. It is used to determine whether the query should be
+	// stopped and whether the peerlist should be updated.
+	HandleResultsFunc HandleResultFn
+
+	// RoutingTable is the routing table used to find closer peers. It is
+	// updated with newly discovered peers.
+	RoutingTable routingtable.RoutingTable
+	// Endpoint is the message endpoint used to send requests
+	Endpoint endpoint.Endpoint
+	// Scheduler is the scheduler used to schedule events for the single worker
+	Scheduler scheduler.Scheduler
+}
+
+// Apply applies the SimpleQuery options to this Option
+func (cfg *Config) Apply(opts ...Option) error {
+	for i, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return fmt.Errorf("SimpleQuery option %d failed: %s", i, err)
+		}
+	}
+	if cfg.RoutingTable == nil {
+		return fmt.Errorf("SimpleQuery option RoutingTable cannot be nil")
+	}
+	if cfg.Endpoint == nil {
+		return fmt.Errorf("SimpleQuery option Endpoint cannot be nil")
+	}
+	if cfg.Scheduler == nil {
+		return fmt.Errorf("SimpleQuery option Scheduler cannot be nil")
+	}
+	return nil
+}
+
+// Option type for SimpleQuery
+type Option func(*Config) error
+
+// DefaultConfig is the default options for SimpleQuery. This option is always
+// prepended to the list of options passed to the SimpleQuery constructor.
+// Note that most of the fields are left empty, and must be filled by the user.
+var DefaultConfig = func(cfg *Config) error {
+	cfg.NumberUsefulCloserPeers = 20
+	cfg.Concurrency = 10
+
+	cfg.RequestTimeout = time.Second
+	cfg.PeerstoreTTL = 30 * time.Minute
+
+	cfg.HandleResultsFunc = func(ctx context.Context, id address.NodeID,
+		resp message.MinKadResponseMessage) (bool, []address.NodeID) {
+		return false, resp.CloserNodes()
+	}
+
+	return nil
+}
+
+func WithProtocolID(pid address.ProtocolID) Option {
+	return func(cfg *Config) error {
+		cfg.ProtocolID = pid
+		return nil
+	}
+}
+
+func WithNumberUsefulCloserPeers(n int) Option {
+	return func(cfg *Config) error {
+		if n <= 0 {
+			return fmt.Errorf("NumberUsefulCloserPeers must be positive")
+		}
+		cfg.NumberUsefulCloserPeers = n
+		return nil
+	}
+}
+
+func WithConcurrency(n int) Option {
+	return func(cfg *Config) error {
+		if n <= 0 {
+			return fmt.Errorf("concurrency parameter must be positive")
+		}
+		cfg.Concurrency = n
+		return nil
+	}
+}
+
+func WithRequestTimeout(timeout time.Duration) Option {
+	return func(cfg *Config) error {
+		cfg.RequestTimeout = timeout
+		return nil
+	}
+}
+
+func WithPeerstoreTTL(ttl time.Duration) Option {
+	return func(cfg *Config) error {
+		cfg.PeerstoreTTL = ttl
+		return nil
+	}
+}
+
+func WithHandleResultsFunc(fn HandleResultFn) Option {
+	return func(cfg *Config) error {
+		if fn == nil {
+			return fmt.Errorf("HandleResultsFunc cannot be nil")
+		}
+		cfg.HandleResultsFunc = fn
+		return nil
+	}
+}
+
+func WithRoutingTable(rt routingtable.RoutingTable) Option {
+	return func(cfg *Config) error {
+		if rt == nil {
+			return fmt.Errorf("SimpleQuery option RoutingTable cannot be nil")
+		}
+		cfg.RoutingTable = rt
+		return nil
+	}
+}
+
+func WithEndpoint(ep endpoint.Endpoint) Option {
+	return func(cfg *Config) error {
+		if ep == nil {
+			return fmt.Errorf("SimpleQuery option Endpoint cannot be nil")
+		}
+		cfg.Endpoint = ep
+		return nil
+	}
+}
+
+func WithScheduler(sched scheduler.Scheduler) Option {
+	return func(cfg *Config) error {
+		if sched == nil {
+			return fmt.Errorf("SimpleQuery option Scheduler cannot be nil")
+		}
+		cfg.Scheduler = sched
+		return nil
+	}
+}

--- a/query/simplequery/query_test.go
+++ b/query/simplequery/query_test.go
@@ -3,27 +3,51 @@ package simplequery
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/benbjohnson/clock"
 	ss "github.com/plprobelab/go-kademlia/events/scheduler/simplescheduler"
+	"github.com/plprobelab/go-kademlia/network/address"
 	si "github.com/plprobelab/go-kademlia/network/address/stringid"
+	fe "github.com/plprobelab/go-kademlia/network/endpoint/fakeendpoint"
+	"github.com/plprobelab/go-kademlia/network/message"
+	sm "github.com/plprobelab/go-kademlia/network/message/simmessage"
+	"github.com/plprobelab/go-kademlia/routingtable/simplert"
+	"github.com/plprobelab/go-kademlia/server/basicserver"
 )
 
 func TestTrivialQuery(t *testing.T) {
 	ctx := context.Background()
 	clk := clock.NewMock()
 
-	//dispatcher := sd.NewSimpleDispatcher(clk)
+	protoID := address.ProtocolID("/test/1.0.0")
+
+	router := fe.NewFakeRouter()
 	node0 := si.StringID("node0")
 	node1 := si.StringID("node1")
 	sched0 := ss.NewSimpleScheduler(clk)
 	sched1 := ss.NewSimpleScheduler(clk)
-	//fendpoint0 := fe.NewFakeEndpoint(node0, dispatcher)
-	//fendpoint1 := fe.NewFakeEndpoint(node1, dispatcher)
+	fendpoint0 := fe.NewFakeEndpoint(node0, sched0, router)
+	fendpoint1 := fe.NewFakeEndpoint(node1, sched1, router)
+	rt0 := simplert.NewSimpleRT(node0.Key(), 1)
+	rt1 := simplert.NewSimpleRT(node1.Key(), 1)
 
-	_ = sched0
-	_ = sched1
-	_ = node0
-	_ = node1
-	_ = ctx
+	server1 := basicserver.NewBasicServer(rt1, fendpoint1)
+	fendpoint1.AddRequestHandler(protoID, &sm.SimMessage{}, server1.HandleRequest)
+
+	req := sm.NewSimRequest(node1.Key())
+	handleResFn := func(context.Context, address.NodeID,
+		message.MinKadResponseMessage) (bool, []address.NodeID) {
+		return true, []address.NodeID{node1}
+	}
+	queryOpts := []Option{
+		WithProtocolID(protoID),
+		WithConcurrency(1),
+		WithRequestTimeout(time.Second),
+		WithHandleResultsFunc(handleResFn),
+		WithRoutingTable(rt0),
+		WithEndpoint(fendpoint0),
+		WithScheduler(sched0),
+	}
+	NewSimpleQuery(ctx, req, queryOpts...)
 }

--- a/server/basicserver/basicserver.go
+++ b/server/basicserver/basicserver.go
@@ -40,7 +40,7 @@ func NewBasicServer(rt routingtable.RoutingTable, endpoint endpoint.Endpoint,
 		rt:                        rt,
 		endpoint:                  endpoint,
 		peerstoreTTL:              cfg.PeerstoreTTL,
-		numberOfCloserPeersToSend: cfg.NumberOfCloserPeersToSend,
+		numberOfCloserPeersToSend: cfg.NumberUsefulCloserPeers,
 	}
 }
 
@@ -69,12 +69,11 @@ func (s *BasicServer) HandleFindNodeRequest(ctx context.Context,
 
 	switch msg := msg.(type) {
 	case *simmessage.SimMessage:
-		t := msg.Target()
-		if t == nil {
+		target = msg.Target()
+		if target == nil {
 			// invalid request (nil target), don't reply
 			return nil, ErrSimMessageNilTarget
 		}
-		target = *t
 	case *ipfsv1.Message:
 		p := peer.ID("")
 		if p.UnmarshalBinary(msg.GetKey()) != nil {

--- a/server/basicserver/basicserver_test.go
+++ b/server/basicserver/basicserver_test.go
@@ -62,7 +62,7 @@ func TestSimMessageHandling(t *testing.T) {
 	}
 
 	s0 := NewBasicServer(rt, fakeEndpoint, WithPeerstoreTTL(peerstoreTTL),
-		WithNumberOfCloserPeersToSend(numberOfCloserPeersToSend))
+		WithNumberUsefulCloserPeers(numberOfCloserPeersToSend))
 
 	requester := kadid.KadID{KadKey: []byte{0b00000001}} // 0000 0001
 
@@ -96,7 +96,7 @@ func TestSimMessageHandling(t *testing.T) {
 	}
 
 	numberOfCloserPeersToSend = 3
-	s1 := NewBasicServer(rt, fakeEndpoint, WithNumberOfCloserPeersToSend(3))
+	s1 := NewBasicServer(rt, fakeEndpoint, WithNumberUsefulCloserPeers(3))
 
 	req2 := simmessage.NewSimRequest([]byte{0b01100000})
 	msg, err = s1.HandleRequest(ctx, requester, req2)
@@ -217,7 +217,7 @@ func TestIPFSv1Handling(t *testing.T) {
 	// peerids[5]: 00ca8d64555add66790c4fb3e62075911a02a3577622fa69279731e82c135b8a (bucket 0)
 
 	s0 := NewBasicServer(rt, fakeEndpoint, WithPeerstoreTTL(peerstoreTTL),
-		WithNumberOfCloserPeersToSend(numberOfCloserPeersToSend))
+		WithNumberUsefulCloserPeers(numberOfCloserPeersToSend))
 
 	requesterPid, err := peer.Decode("1WoooREQUESTER")
 	require.NoError(t, err)
@@ -303,7 +303,7 @@ func TestInvalidIpfsv1Requests(t *testing.T) {
 	}
 
 	s0 := NewBasicServer(rt, invalidEP, WithPeerstoreTTL(peerstoreTTL),
-		WithNumberOfCloserPeersToSend(numberOfCloserPeersToSend))
+		WithNumberUsefulCloserPeers(numberOfCloserPeersToSend))
 
 	requesterPid, err := peer.Decode("1WoooREQUESTER")
 	require.NoError(t, err)

--- a/server/basicserver/options.go
+++ b/server/basicserver/options.go
@@ -6,30 +6,30 @@ import (
 )
 
 // Config is a structure containing all the options that can be used when
-// constructing a SimpleRouting.
+// constructing a BasicServer.
 type Config struct {
-	PeerstoreTTL              time.Duration
-	NumberOfCloserPeersToSend int
+	PeerstoreTTL            time.Duration
+	NumberUsefulCloserPeers int
 }
 
-// Apply applies the givkadsimservern options to this Option
+// Apply applies the BasicServer options to this Option
 func (cfg *Config) Apply(opts ...Option) error {
 	for i, opt := range opts {
 		if err := opt(cfg); err != nil {
-			return fmt.Errorf("SimpleRouting option %d failed: %s", i, err)
+			return fmt.Errorf("BasicServer option %d failed: %s", i, err)
 		}
 	}
 	return nil
 }
 
-// Option type for SimpleRouting
+// Option type for BasicServer
 type Option func(*Config) error
 
-// DefaultConfig is the default options for SimpleRouting. This option is always
-// prepended to the list of options passed to the SimpleRouting constructor.
+// DefaultConfig is the default options for BasicServer. This option is always
+// prepended to the list of options passed to the BasicServer constructor.
 var DefaultConfig = func(cfg *Config) error {
-	cfg.PeerstoreTTL = 10 * time.Minute
-	cfg.NumberOfCloserPeersToSend = 20
+	cfg.PeerstoreTTL = 30 * time.Minute
+	cfg.NumberUsefulCloserPeers = 20
 
 	return nil
 }
@@ -41,9 +41,9 @@ func WithPeerstoreTTL(ttl time.Duration) Option {
 	}
 }
 
-func WithNumberOfCloserPeersToSend(n int) Option {
+func WithNumberUsefulCloserPeers(n int) Option {
 	return func(cfg *Config) error {
-		cfg.NumberOfCloserPeersToSend = n
+		cfg.NumberUsefulCloserPeers = n
 		return nil
 	}
 }


### PR DESCRIPTION
Example of how to create and use a DHT object, demonstrating the use of the IPFS `FIND_PEER` RPC.