### PR TITLE
Remove stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,0 @@
-name: Close and mark stale issue
-
-on:
-  schedule:
-  - cron: '0 0 * * *'
-
-jobs:
-  stale:
-    uses: pl-strflt/.github/.github/workflows/reusable-stale-issue.yml@v0.3


### PR DESCRIPTION
Remove the `stale` workflow, because issues contain important action items, and may be inactive for a while, we don't want to close them yet.