### PR TITLE
Generic kadkey

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -16,7 +16,7 @@ type KadKey256 = KadKey[[256]byte]
 func New[T any](data []byte) KadKey[T] {
 	var v T
 	if uintptr(len(data)) != unsafe.Sizeof(v) {
-		panic("invalid data lenght for key")
+		panic("invalid data length for key")
 	}
 	return KadKey[T]{bytes: data}
 }

--- a/key/key.go
+++ b/key/key.go
@@ -1,69 +1,62 @@
 package key
 
 import (
+	"bytes"
 	"encoding/hex"
 	"math"
+	"unsafe"
 )
 
-type KadKey []byte
-
-func (k KadKey) Size() int {
-	return len(k)
+type KadKey[T any] struct {
+	bytes []byte
 }
 
-func (k KadKey) Hex() string {
-	return hex.EncodeToString(k[:])
+type KadKey256 = KadKey[[256]byte]
+
+func New[T any](data []byte) KadKey[T] {
+	var v T
+	if uintptr(len(data)) != unsafe.Sizeof(v) {
+		panic("invalid data lenght for key")
+	}
+	return KadKey[T]{bytes: data}
 }
 
-func (k KadKey) String() string {
+func (k KadKey[T]) Size() int {
+	return len(k.bytes)
+}
+
+func (k KadKey[T]) Hex() string {
+	return hex.EncodeToString(k.bytes[:])
+}
+
+func (k KadKey[T]) String() string {
 	return k.Hex()
 }
 
-func (a KadKey) Xor(b KadKey) (KadKey, error) {
-	if a.Size() != b.Size() {
-		return nil, ErrInvalidKey(a.Size())
-	}
-
+func (a KadKey[T]) Xor(b KadKey[T]) KadKey[T] {
 	xored := make([]byte, a.Size())
 	for i := 0; i < a.Size(); i++ {
-		xored[i] = a[i] ^ b[i]
+		xored[i] = a.bytes[i] ^ b.bytes[i]
 	}
-	return xored, nil
+	return KadKey[T]{bytes: xored}
 }
 
-func (a KadKey) CommonPrefixLength(b KadKey) (int, error) {
-	if a.Size() != b.Size() {
-		return 0, ErrInvalidKey(a.Size())
-	}
-
+func (a KadKey[T]) CommonPrefixLength(b KadKey[T]) int {
 	var xored byte
 	for i := 0; i < a.Size(); i++ {
-		xored = a[i] ^ b[i]
+		xored = a.bytes[i] ^ b.bytes[i]
 		if xored != 0 {
-			return i*8 + 7 - int(math.Log2(float64(xored))), nil
+			return i*8 + 7 - int(math.Log2(float64(xored)))
 		}
 	}
-	return 8 * a.Size(), nil
+	return 8 * a.Size()
 }
 
 // Compare returns -1 if a < b, 0 if a == b, and 1 if a > b
-func (a KadKey) Compare(b KadKey) (int8, error) {
-	if a.Size() != b.Size() {
-		return 2, ErrInvalidKey(a.Size())
-	}
-
-	for i := 0; i < a.Size(); i++ {
-		if a[i] < b[i] {
-			return -1, nil
-		}
-		if a[i] > b[i] {
-			return 1, nil
-		}
-	}
-	return 0, nil
+func (a KadKey[T]) Compare(b KadKey[T]) int {
+	return bytes.Compare(a.bytes, b.bytes)
 }
 
-func (a KadKey) Equal(b KadKey) (bool, error) {
-	cmp, err := a.Compare(b)
-	return cmp == 0, err
+func (a KadKey[T]) Equal(b KadKey[T]) bool {
+	return a.Compare(b) == 0
 }

--- a/key/key.go
+++ b/key/key.go
@@ -11,7 +11,11 @@ type KadKey[T any] struct {
 	bytes []byte
 }
 
-type KadKey256 = KadKey[[256]byte]
+type KadKey256 = KadKey[[32]byte]
+
+func NewKadKey256(data []byte) KadKey256 {
+	return New[[32]byte](data)
+}
 
 func New[T any](data []byte) KadKey[T] {
 	var v T

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -7,7 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var keysize = 4
+const keysize = 4
+
+type TestKadKey = KadKey[[keysize]byte]
+
+func NewTestKadKey(data []byte) TestKadKey {
+	return New[[keysize]byte](data)
+}
 
 func zeroBytes(n int) []byte {
 	bytes := make([]byte, n)
@@ -18,7 +24,7 @@ func zeroBytes(n int) []byte {
 }
 
 func TestKadKeyString(t *testing.T) {
-	zeroKadid := KadKey(zeroBytes(keysize))
+	zeroKadid := NewTestKadKey(zeroBytes(keysize))
 	zeroHex := strings.Repeat("00", keysize)
 	require.Equal(t, zeroHex, zeroKadid.String())
 
@@ -27,83 +33,68 @@ func TestKadKeyString(t *testing.T) {
 		ffKadid[i] = 0xff
 	}
 	ffHex := strings.Repeat("ff", keysize)
-	require.Equal(t, ffHex, KadKey(ffKadid).String())
+	require.Equal(t, ffHex, NewTestKadKey(ffKadid).String())
 
 	e3Kadid := make([]byte, keysize)
 	for i := 0; i < keysize; i++ {
 		e3Kadid[i] = 0xe3
 	}
 	e3Hex := strings.Repeat("e3", keysize)
-	require.Equal(t, e3Hex, KadKey(e3Kadid).String())
+	require.Equal(t, e3Hex, NewTestKadKey(e3Kadid).String())
 }
 
 func TestXor(t *testing.T) {
-	key0 := KadKey(zeroBytes(keysize))                // 00000...000
-	randKey := KadKey([]byte{0x23, 0xe4, 0xdd, 0x03}) // arbitrary key
+	key0 := NewTestKadKey(zeroBytes(keysize))                // 00000...000
+	randKey := NewTestKadKey([]byte{0x23, 0xe4, 0xdd, 0x03}) // arbitrary key
 
-	xored, err := key0.Xor(key0)
-	require.NoError(t, err)
+	xored := key0.Xor(key0)
 	require.Equal(t, key0, xored)
-	xored, _ = randKey.Xor(key0)
+	xored = randKey.Xor(key0)
 	require.Equal(t, randKey, xored)
-	xored, _ = key0.Xor(randKey)
+	xored = key0.Xor(randKey)
 	require.Equal(t, randKey, xored)
-	xored, _ = randKey.Xor(randKey)
+	xored = randKey.Xor(randKey)
 	require.Equal(t, key0, xored)
-
-	invalidKey := KadKey([]byte{0x23, 0xe4, 0xdd}) // invalid key
-	_, err = key0.Xor(invalidKey)
-	require.Equal(t, ErrInvalidKey(4), err)
 }
 
 func TestCommonPrefixLength(t *testing.T) {
-	key0 := KadKey(zeroBytes(keysize))                            // 00000...000
-	key1 := KadKey(append(zeroBytes(keysize-1), 0x01))            // 00000...001
-	key2 := KadKey(append([]byte{0x80}, zeroBytes(keysize-1)...)) // 10000...000
-	key3 := KadKey(append([]byte{0x40}, zeroBytes(keysize-1)...)) // 01000...000
+	key0 := NewTestKadKey(zeroBytes(keysize))                            // 00000...000
+	key1 := NewTestKadKey(append(zeroBytes(keysize-1), 0x01))            // 00000...001
+	key2 := NewTestKadKey(append([]byte{0x80}, zeroBytes(keysize-1)...)) // 10000...000
+	key3 := NewTestKadKey(append([]byte{0x40}, zeroBytes(keysize-1)...)) // 01000...000
 
-	cpl, err := key0.CommonPrefixLength(key0)
-	require.NoError(t, err)
+	cpl := key0.CommonPrefixLength(key0)
 	require.Equal(t, keysize*8, cpl)
-	cpl, _ = key0.CommonPrefixLength(key1)
+	cpl = key0.CommonPrefixLength(key1)
 	require.Equal(t, keysize*8-1, cpl)
-	cpl, _ = key0.CommonPrefixLength(key2)
+	cpl = key0.CommonPrefixLength(key2)
 	require.Equal(t, 0, cpl)
-	cpl, _ = key0.CommonPrefixLength(key3)
+	cpl = key0.CommonPrefixLength(key3)
 	require.Equal(t, 1, cpl)
-
-	invalidKey := KadKey([]byte{0x23, 0xe4, 0xdd}) // invalid key
-	_, err = key0.CommonPrefixLength(invalidKey)
-	require.Equal(t, ErrInvalidKey(4), err)
 }
 
 func TestCompare(t *testing.T) {
 	nKeys := 5
-	keys := make([]KadKey, nKeys)
+	keys := make([]TestKadKey, nKeys)
 	// ascending order
-	keys[0] = KadKey(zeroBytes(keysize))                            // 00000...000
-	keys[1] = KadKey(append(zeroBytes(keysize-1), 0x01))            // 00000...001
-	keys[2] = KadKey(append(zeroBytes(keysize-1), 0x02))            // 00000...010
-	keys[3] = KadKey(append([]byte{0x40}, zeroBytes(keysize-1)...)) // 01000...000
-	keys[4] = KadKey(append([]byte{0x80}, zeroBytes(keysize-1)...)) // 10000...000
+	keys[0] = NewTestKadKey(zeroBytes(keysize))                            // 00000...000
+	keys[1] = NewTestKadKey(append(zeroBytes(keysize-1), 0x01))            // 00000...001
+	keys[2] = NewTestKadKey(append(zeroBytes(keysize-1), 0x02))            // 00000...010
+	keys[3] = NewTestKadKey(append([]byte{0x40}, zeroBytes(keysize-1)...)) // 01000...000
+	keys[4] = NewTestKadKey(append([]byte{0x80}, zeroBytes(keysize-1)...)) // 10000...000
 
 	for i := 0; i < nKeys; i++ {
 		for j := 0; j < nKeys; j++ {
-			res, _ := keys[i].Compare(keys[j])
+			res := keys[i].Compare(keys[j])
 			if i < j {
-				require.Equal(t, int8(-1), res)
+				require.Equal(t, int(-1), res)
 			} else if i > j {
-				require.Equal(t, int8(1), res)
+				require.Equal(t, int(1), res)
 			} else {
-				require.Equal(t, int8(0), res)
-				equal, err := keys[i].Equal(keys[j])
-				require.NoError(t, err)
+				require.Equal(t, int(0), res)
+				equal := keys[i].Equal(keys[j])
 				require.True(t, equal)
 			}
 		}
 	}
-
-	invalidKey := KadKey([]byte{0x23, 0xe4, 0xdd}) // invalid key
-	_, err := keys[0].Compare(invalidKey)
-	require.Equal(t, ErrInvalidKey(4), err)
 }

--- a/key/sha256key256/util.go
+++ b/key/sha256key256/util.go
@@ -20,9 +20,9 @@ const (
 
 // StringKadID produces a 256-bit long KadKey from a string, using the SHA256
 // hash function.
-func StringKadID(s string) key.KadKey {
+func StringKadID(s string) key.KadKey256 {
 	// hasher is the hash function used to derive the second hash identifiers
 	hasher, _ := mhreg.GetHasher(HasherID)
 	hasher.Write([]byte(s))
-	return key.KadKey(hasher.Sum(nil))
+	return key.NewKadKey256(hasher.Sum(nil))
 }

--- a/network/address/address.go
+++ b/network/address/address.go
@@ -4,13 +4,15 @@ import "github.com/plprobelab/go-kademlia/key"
 
 // NodeID is a generic node identifier. It is used to identify a node and can
 // also include extra information about the node, such as its network addresses.
-type NodeID interface {
+type NodeID[T any] interface {
 	// Key returns the KadKey of the NodeID.
-	Key() key.KadKey
+	Key() key.KadKey[T]
 	// String returns the string representation of the NodeID. String
 	// representation should be unique for each NodeID.
 	String() string
 }
+
+type NodeID256 = NodeID[[32]byte]
 
 // ProtocolID is a protocol identifier.
 type ProtocolID string

--- a/network/address/addrinfo/addrinfo.go
+++ b/network/address/addrinfo/addrinfo.go
@@ -12,7 +12,7 @@ type AddrInfo struct {
 	id *peerid.PeerID
 }
 
-var _ address.NodeID = (*AddrInfo)(nil)
+var _ address.NodeID[[32]byte] = (*AddrInfo)(nil)
 
 func NewAddrInfo(ai peer.AddrInfo) *AddrInfo {
 	return &AddrInfo{
@@ -21,7 +21,7 @@ func NewAddrInfo(ai peer.AddrInfo) *AddrInfo {
 	}
 }
 
-func (ai AddrInfo) Key() key.KadKey {
+func (ai AddrInfo) Key() key.KadKey256 {
 	return ai.id.Key()
 }
 

--- a/network/address/kadid/kadid.go
+++ b/network/address/kadid/kadid.go
@@ -5,24 +5,24 @@ import (
 	"github.com/plprobelab/go-kademlia/network/address"
 )
 
-type KadID struct {
-	key.KadKey
+type KadID[T any] struct {
+	key.KadKey[T]
 }
 
-var _ address.NodeID = (*KadID)(nil)
+// var _ address.NodeID[T] = (*KadID[T])(nil)
 
-func NewKadID(k key.KadKey) *KadID {
-	return &KadID{k}
+func NewKadID[T any](k key.KadKey[T]) *KadID[T] {
+	return &KadID[T]{k}
 }
 
-func (k KadID) Key() key.KadKey {
+func (k KadID[T]) Key() key.KadKey[T] {
 	return k.KadKey
 }
 
-func (k KadID) NodeID() address.NodeID {
+func (k KadID[T]) NodeID() address.NodeID[T] {
 	return &k
 }
 
-func (k KadID) String() string {
+func (k KadID[T]) String() string {
 	return k.Hex()
 }

--- a/network/address/peerid/peerid.go
+++ b/network/address/peerid/peerid.go
@@ -12,16 +12,16 @@ type PeerID struct {
 	peer.ID
 }
 
-var _ address.NodeID = (*PeerID)(nil)
+var _ address.NodeID256 = (*PeerID)(nil)
 
 func NewPeerID(p peer.ID) *PeerID {
 	return &PeerID{p}
 }
 
-func (id PeerID) Key() key.KadKey {
+func (id PeerID) Key() key.KadKey256 {
 	return builder.StringKadID(string(id.ID))
 }
 
-func (id PeerID) NodeID() address.NodeID {
+func (id PeerID) NodeID() address.NodeID256 {
 	return &id
 }

--- a/network/address/stringid/stringid.go
+++ b/network/address/stringid/stringid.go
@@ -8,9 +8,9 @@ import (
 
 type StringID string
 
-var _ address.NodeID = (*StringID)(nil)
+var _ address.NodeID256 = (*StringID)(nil)
 
-func NewStringID(s string) *StringID {
+func NewStringID[T any](s string) *StringID {
 	return (*StringID)(&s)
 }
 
@@ -18,10 +18,10 @@ func (s StringID) String() string {
 	return string(s)
 }
 
-func (s StringID) Key() key.KadKey {
+func (s StringID) Key() key.KadKey256 {
 	return builder.StringKadID(s.String())
 }
 
-func (s StringID) NodeID() address.NodeID {
+func (s StringID) NodeID() address.NodeID256 {
 	return &s
 }


### PR DESCRIPTION
When https://github.com/golang/go/issues/44253 is implemented we could replace `any` by `[...]byte`