### PR TITLE
Add routing table NodeID[K] type parameter

### DIFF
--- a/coord/coordinator.go
+++ b/coord/coordinator.go
@@ -35,7 +35,7 @@ type Coordinator[K kad.Key[K], A kad.Address[A]] struct {
 	qp *query.Pool[K, A]
 
 	// rt is the routing table used to look up nodes by distance
-	rt kad.RoutingTable[K]
+	rt kad.RoutingTable[K, kad.NodeID[K]]
 
 	// ep is the message endpoint used to send requests
 	ep endpoint.Endpoint[K, A]
@@ -76,7 +76,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-func NewCoordinator[K kad.Key[K], A kad.Address[A]](self kad.NodeID[K], ep endpoint.Endpoint[K, A], rt kad.RoutingTable[K], cfg *Config) (*Coordinator[K, A], error) {
+func NewCoordinator[K kad.Key[K], A kad.Address[A]](self kad.NodeID[K], ep endpoint.Endpoint[K, A], rt kad.RoutingTable[K, kad.NodeID[K]], cfg *Config) (*Coordinator[K, A], error) {
 	if cfg == nil {
 		cfg = DefaultConfig()
 	} else if err := cfg.Validate(); err != nil {

--- a/coord/coordinator_test.go
+++ b/coord/coordinator_test.go
@@ -33,7 +33,7 @@ var (
 	_ coordinatorInternalEvent = &eventStopQuery[key.Key8]{}
 )
 
-func setupSimulation(t *testing.T, ctx context.Context) ([]kad.NodeInfo[key.Key8, kadtest.StrAddr], []*sim.Endpoint[key.Key8, kadtest.StrAddr], []kad.RoutingTable[key.Key8], *litesimulator.LiteSimulator) {
+func setupSimulation(t *testing.T, ctx context.Context) ([]kad.NodeInfo[key.Key8, kadtest.StrAddr], []*sim.Endpoint[key.Key8, kadtest.StrAddr], []kad.RoutingTable[key.Key8, kad.NodeID[key.Key8]], *litesimulator.LiteSimulator) {
 	// create node identifiers
 	nodeCount := 4
 	ids := make([]*kadtest.ID[key.Key8], nodeCount)
@@ -59,7 +59,7 @@ func setupSimulation(t *testing.T, ctx context.Context) ([]kad.NodeInfo[key.Key8
 	// create a fake router to virtually connect nodes
 	router := sim.NewRouter[key.Key8, kadtest.StrAddr]()
 
-	rts := make([]kad.RoutingTable[key.Key8], len(addrs))
+	rts := make([]kad.RoutingTable[key.Key8, kad.NodeID[key.Key8]], len(addrs))
 	eps := make([]*sim.Endpoint[key.Key8, kadtest.StrAddr], len(addrs))
 	schedulers := make([]scheduler.AwareScheduler, len(addrs))
 	servers := make([]*sim.Server[key.Key8, kadtest.StrAddr], len(addrs))
@@ -67,7 +67,7 @@ func setupSimulation(t *testing.T, ctx context.Context) ([]kad.NodeInfo[key.Key8
 	for i := 0; i < len(addrs); i++ {
 		i := i // :(
 		// create a routing table, with bucket size 2
-		rts[i] = simplert.New(addrs[i].ID().Key(), 2)
+		rts[i] = simplert.New[key.Key8, kad.NodeID[key.Key8]](addrs[i].ID(), 2)
 		// create a scheduler based on the mock clock
 		schedulers[i] = ss.NewSimpleScheduler(clk)
 		// create a fake endpoint for the node, communicating through the router
@@ -99,7 +99,7 @@ func setupSimulation(t *testing.T, ctx context.Context) ([]kad.NodeInfo[key.Key8
 
 // connectNodes adds nodes to each other's peerstores and routing tables
 func connectNodes(t *testing.T, n0, n1 kad.NodeInfo[key.Key8, kadtest.StrAddr], ep0, ep1 endpoint.Endpoint[key.Key8, kadtest.StrAddr],
-	rt0, rt1 kad.RoutingTable[key.Key8],
+	rt0, rt1 kad.RoutingTable[key.Key8, kad.NodeID[key.Key8]],
 ) {
 	t.Helper()
 

--- a/examples/connect/findpeer.go
+++ b/examples/connect/findpeer.go
@@ -36,11 +36,9 @@ func FindPeer(ctx context.Context) {
 	}
 
 	pid := libp2p.NewPeerID(h.ID())
-	// get the peer's kademlia key (derived from its peer.ID)
-	kadid := pid.Key()
 
 	// create a simple routing table, with bucket size 20
-	rt := simplert.New(kadid, 20)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](pid, 20)
 	// create a scheduler using real time
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	// create a message endpoint is used to communicate with other peers

--- a/examples/dispatchquery/main.go
+++ b/examples/dispatchquery/main.go
@@ -55,7 +55,7 @@ func queryTest(ctx context.Context) {
 		ID:    selfA.ID,
 		Addrs: []multiaddr.Multiaddr{addrA},
 	})
-	rtA := simplert.New(selfA.Key(), 2)
+	rtA := simplert.New[key.Key256, kad.NodeID[key.Key256]](selfA, 2)
 	schedA := ss.NewSimpleScheduler(clk)
 	endpointA := sim.NewEndpoint(selfA.NodeID(), schedA, router)
 	servA := basicserver.NewBasicServer[multiaddr.Multiaddr](rtA, endpointA)
@@ -75,7 +75,7 @@ func queryTest(ctx context.Context) {
 		ID:    selfB.ID,
 		Addrs: []multiaddr.Multiaddr{addrB},
 	})
-	rtB := simplert.New(selfB.Key(), 2)
+	rtB := simplert.New[key.Key256, kad.NodeID[key.Key256]](selfB, 2)
 	schedB := ss.NewSimpleScheduler(clk)
 	endpointB := sim.NewEndpoint(selfB.NodeID(), schedB, router)
 	servB := basicserver.NewBasicServer[multiaddr.Multiaddr](rtB, endpointB)
@@ -95,7 +95,7 @@ func queryTest(ctx context.Context) {
 		ID:    selfC.ID,
 		Addrs: []multiaddr.Multiaddr{addrC},
 	})
-	rtC := simplert.New(selfC.Key(), 2)
+	rtC := simplert.New[key.Key256, kad.NodeID[key.Key256]](selfC, 2)
 	schedC := ss.NewSimpleScheduler(clk)
 	endpointC := sim.NewEndpoint(selfC.NodeID(), schedC, router)
 	servC := basicserver.NewBasicServer[multiaddr.Multiaddr](rtC, endpointC)

--- a/examples/fullsim/findnode.go
+++ b/examples/fullsim/findnode.go
@@ -31,7 +31,7 @@ const (
 
 // connectNodes adds nodes to each other's peerstores and routing tables
 func connectNodes(ctx context.Context, n0, n1 kad.NodeInfo[key.Key8, net.IP], ep0, ep1 endpoint.Endpoint[key.Key8, net.IP],
-	rt0, rt1 kad.RoutingTable[key.Key8],
+	rt0, rt1 kad.RoutingTable[key.Key8, kad.NodeID[key.Key8]],
 ) {
 	// add n1 to n0's peerstore and routing table
 	ep0.MaybeAddToPeerstore(ctx, n1, peerstoreTTL)
@@ -64,14 +64,14 @@ func findNode(ctx context.Context) {
 	//   ^   ^
 	//  A B C D
 
-	rts := make([]*simplert.SimpleRT[key.Key8], len(nodes))
+	rts := make([]*simplert.SimpleRT[key.Key8, kad.NodeID[key.Key8]], len(nodes))
 	eps := make([]*sim.Endpoint[key.Key8, net.IP], len(nodes))
 	schedulers := make([]scheduler.AwareScheduler, len(nodes))
 	servers := make([]server.Server[key.Key8], len(nodes))
 
 	for i := 0; i < len(nodes); i++ {
 		// create a routing table, with bucket size 2
-		rts[i] = simplert.New[key.Key8](nodes[i].ID().Key(), 2)
+		rts[i] = simplert.New[key.Key8, kad.NodeID[key.Key8]](nodes[i].ID(), 2)
 		// create a scheduler based on the mock clock
 		schedulers[i] = ss.NewSimpleScheduler(clk)
 		// create a fake endpoint for the node, communicating through the router

--- a/examples/statemachine/main.go
+++ b/examples/statemachine/main.go
@@ -99,7 +99,7 @@ func main() {
 
 const peerstoreTTL = 10 * time.Minute
 
-func setupSimulation(ctx context.Context) ([]kad.NodeInfo[key.Key256, net.IP], []*sim.Endpoint[key.Key256, net.IP], []kad.RoutingTable[key.Key256], *litesimulator.LiteSimulator) {
+func setupSimulation(ctx context.Context) ([]kad.NodeInfo[key.Key256, net.IP], []*sim.Endpoint[key.Key256, net.IP], []kad.RoutingTable[key.Key256, kad.NodeID[key.Key256]], *litesimulator.LiteSimulator) {
 	// create node identifiers
 	nodeCount := 4
 	ids := make([]*kadtest.ID[key.Key256], nodeCount)
@@ -150,7 +150,7 @@ func setupSimulation(ctx context.Context) ([]kad.NodeInfo[key.Key256, net.IP], [
 	// create a fake router to virtually connect nodes
 	router := sim.NewRouter[key.Key256, net.IP]()
 
-	rts := make([]kad.RoutingTable[key.Key256], len(addrs))
+	rts := make([]kad.RoutingTable[key.Key256, kad.NodeID[key.Key256]], len(addrs))
 	eps := make([]*sim.Endpoint[key.Key256, net.IP], len(addrs))
 	schedulers := make([]scheduler.AwareScheduler, len(addrs))
 	servers := make([]*sim.Server[key.Key256, net.IP], len(addrs))
@@ -158,7 +158,7 @@ func setupSimulation(ctx context.Context) ([]kad.NodeInfo[key.Key256, net.IP], [
 	for i := 0; i < len(addrs); i++ {
 		i := i // :(
 		// create a routing table, with bucket size 2
-		rts[i] = simplert.New(addrs[i].ID().Key(), 2)
+		rts[i] = simplert.New[key.Key256, kad.NodeID[key.Key256]](addrs[i].ID(), 2)
 		// create a scheduler based on the mock clock
 		schedulers[i] = ss.NewSimpleScheduler(clk)
 		// create a fake endpoint for the node, communicating through the router
@@ -190,7 +190,7 @@ func setupSimulation(ctx context.Context) ([]kad.NodeInfo[key.Key256, net.IP], [
 
 // connectNodes adds nodes to each other's peerstores and routing tables
 func connectNodes(ctx context.Context, n0, n1 kad.NodeInfo[key.Key256, net.IP], ep0, ep1 endpoint.Endpoint[key.Key256, net.IP],
-	rt0, rt1 kad.RoutingTable[key.Key256],
+	rt0, rt1 kad.RoutingTable[key.Key256, kad.NodeID[key.Key256]],
 ) {
 	// add n1 to n0's peerstore and routing table
 	debug("connecting %s to %s", n0.ID(), n1.ID())

--- a/kad/kad.go
+++ b/kad/kad.go
@@ -35,7 +35,7 @@ type Key[K any] interface {
 }
 
 // RoutingTable is the interface all Kademlia Routing Tables types support.
-type RoutingTable[K Key[K]] interface {
+type RoutingTable[K Key[K], N NodeID[K]] interface {
 	// AddNode tries to add a peer to the routing table. It returns true if
 	// the node was added and false if it wasn't added, e.g., because it
 	// was already part of the routing table.
@@ -48,7 +48,7 @@ type RoutingTable[K Key[K]] interface {
 	// Nodes added to the routing table are grouped into buckets based on their
 	// XOR distance to the local node's identifier. The details of the XOR
 	// arithmetics are defined on K.
-	AddNode(NodeID[K]) bool
+	AddNode(N) bool
 
 	// RemoveKey tries to remove a node identified by its Kademlia key from the
 	// routing table.
@@ -63,7 +63,7 @@ type RoutingTable[K Key[K]] interface {
 	// The returned list of nodes will be ordered from closest to furthest and
 	// contain at maximum the given number of entries, but also possibly less
 	// if the number exceeds the number of nodes in the routing table.
-	NearestNodes(K, int) []NodeID[K]
+	NearestNodes(K, int) []N
 }
 
 // NodeID is a generic node identifier and not equal to a Kademlia key. Some

--- a/libp2p/query_test.go
+++ b/libp2p/query_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/plprobelab/go-kademlia/kad"
+
 	"github.com/benbjohnson/clock"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -38,7 +40,7 @@ func TestLibp2pCornerCase(t *testing.T) {
 	id := NewPeerID(h.ID())
 	sched := ss.NewSimpleScheduler(clk)
 	libp2pEndpoint := NewLibp2pEndpoint(ctx, h, sched)
-	rt := simplert.New[key.Key256](id.Key(), bucketSize)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](id, bucketSize)
 
 	parsed, err := peer.Decode("1D3oooUnknownPeer")
 	require.NoError(t, err)

--- a/query/simplequery/options.go
+++ b/query/simplequery/options.go
@@ -38,7 +38,7 @@ type Config[K kad.Key[K], A kad.Address[A]] struct {
 
 	// RoutingTable is the routing table used to find closer peers. It is
 	// updated with newly discovered peers.
-	RoutingTable kad.RoutingTable[K]
+	RoutingTable kad.RoutingTable[K, kad.NodeID[K]]
 	// Endpoint is the message endpoint used to send requests
 	Endpoint endpoint.Endpoint[K, A]
 	// Scheduler is the scheduler used to schedule events for the single worker
@@ -152,7 +152,7 @@ func WithNotifyFailureFunc[K kad.Key[K], A kad.Address[A]](fn NotifyFailureFn) O
 	}
 }
 
-func WithRoutingTable[K kad.Key[K], A kad.Address[A]](rt kad.RoutingTable[K]) Option[K, A] {
+func WithRoutingTable[K kad.Key[K], A kad.Address[A]](rt kad.RoutingTable[K, kad.NodeID[K]]) Option[K, A] {
 	return func(cfg *Config[K, A]) error {
 		if rt == nil {
 			return fmt.Errorf("SimpleQuery option RoutingTable cannot be nil")

--- a/query/simplequery/query.go
+++ b/query/simplequery/query.go
@@ -39,7 +39,7 @@ type SimpleQuery[K kad.Key[K], A kad.Address[A]] struct {
 	timeout      time.Duration
 
 	msgEndpoint endpoint.Endpoint[K, A]
-	rt          kad.RoutingTable[K]
+	rt          kad.RoutingTable[K, kad.NodeID[K]]
 	sched       scheduler.Scheduler
 
 	inflightRequests int // requests that are either in flight or scheduled

--- a/routing/triert/config.go
+++ b/routing/triert/config.go
@@ -5,15 +5,15 @@ import (
 )
 
 // Config holds configuration options for a TrieRT.
-type Config[T kad.Key[T]] struct {
+type Config[K kad.Key[K], N kad.NodeID[K]] struct {
 	// KeyFilter defines the filter that is applied before a key is added to the table.
 	// If nil, no filter is applied.
-	KeyFilter KeyFilterFunc[T]
+	KeyFilter KeyFilterFunc[K, N]
 }
 
 // DefaultConfig returns a default configuration for a TrieRT.
-func DefaultConfig[T kad.Key[T]]() *Config[T] {
-	return &Config[T]{
+func DefaultConfig[K kad.Key[K], N kad.NodeID[K]]() *Config[K, N] {
+	return &Config[K, N]{
 		KeyFilter: nil,
 	}
 }

--- a/routing/triert/filter.go
+++ b/routing/triert/filter.go
@@ -4,10 +4,10 @@ import "github.com/plprobelab/go-kademlia/kad"
 
 // KeyFilterFunc is a function that is applied before a key is added to the table.
 // Return false to prevent the key from being added.
-type KeyFilterFunc[K kad.Key[K]] func(rt *TrieRT[K], kk K) bool
+type KeyFilterFunc[K kad.Key[K], N kad.NodeID[K]] func(rt *TrieRT[K, N], kk K) bool
 
 // BucketLimit20 is a filter function that limits the occupancy of buckets in the table to 20 keys.
-func BucketLimit20[K kad.Key[K]](rt *TrieRT[K], kk K) bool {
+func BucketLimit20[K kad.Key[K], N kad.NodeID[K]](rt *TrieRT[K, N], kk K) bool {
 	cpl := rt.Cpl(kk)
 	return rt.CplSize(cpl) < 20
 }

--- a/routing/triert/filter_test.go
+++ b/routing/triert/filter_test.go
@@ -5,21 +5,20 @@ import (
 	"testing"
 
 	"github.com/plprobelab/go-kademlia/internal/kadtest"
-	"github.com/plprobelab/go-kademlia/kad"
 	"github.com/plprobelab/go-kademlia/key"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBucketLimit20(t *testing.T) {
-	cfg := DefaultConfig[key.Key32]()
-	cfg.KeyFilter = BucketLimit20[key.Key32]
-	rt, err := New(key0, cfg)
+	cfg := DefaultConfig[key.Key32, node[key.Key32]]()
+	cfg.KeyFilter = BucketLimit20[key.Key32, node[key.Key32]]
+	rt, err := New(node0, cfg)
 	require.NoError(t, err)
 
-	nodes := make([]kad.NodeID[key.Key32], 21)
+	nodes := make([]node[key.Key32], 21)
 	for i := range nodes {
 		kk := kadtest.RandomKeyWithPrefix("000100")
-		nodes[i] = NewNode(fmt.Sprintf("QmPeer%d", i), kk)
+		nodes[i] = newNode(fmt.Sprintf("QmPeer%d", i), kk)
 	}
 
 	// Add 20 peers with cpl 3
@@ -34,7 +33,7 @@ func TestBucketLimit20(t *testing.T) {
 
 	// add peer with different cpl
 	kk := kadtest.RandomKeyWithPrefix("0000100")
-	node22 := NewNode("QmPeer22", kk)
+	node22 := newNode("QmPeer22", kk)
 	success = rt.AddNode(node22)
 	require.True(t, success)
 

--- a/routing/triert/table.go
+++ b/routing/triert/table.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/plprobelab/go-kademlia/internal/kadtest"
+
 	"github.com/plprobelab/go-kademlia/key"
 
 	"github.com/plprobelab/go-kademlia/kad"
@@ -12,21 +14,21 @@ import (
 
 // TrieRT is a routing table backed by a XOR Trie which offers good scalablity and performance
 // for large networks.
-type TrieRT[K kad.Key[K]] struct {
+type TrieRT[K kad.Key[K], N kad.NodeID[K]] struct {
 	self      K
-	keyFilter KeyFilterFunc[K]
+	keyFilter KeyFilterFunc[K, N]
 
-	keys *trie.Trie[K, kad.NodeID[K]]
+	keys *trie.Trie[K, N]
 }
 
-var _ kad.RoutingTable[key.Key256] = (*TrieRT[key.Key256])(nil)
+var _ kad.RoutingTable[key.Key256, kadtest.ID[key.Key256]] = (*TrieRT[key.Key256, kadtest.ID[key.Key256]])(nil)
 
 // New creates a new TrieRT using the supplied key as the local node's Kademlia key.
 // If cfg is nil, the default config is used.
-func New[K kad.Key[K]](self K, cfg *Config[K]) (*TrieRT[K], error) {
-	rt := &TrieRT[K]{
-		self: self,
-		keys: &trie.Trie[K, kad.NodeID[K]]{},
+func New[K kad.Key[K], N kad.NodeID[K]](self N, cfg *Config[K, N]) (*TrieRT[K, N], error) {
+	rt := &TrieRT[K, N]{
+		self: self.Key(),
+		keys: &trie.Trie[K, N]{},
 	}
 	if err := rt.apply(cfg); err != nil {
 		return nil, fmt.Errorf("apply config: %w", err)
@@ -34,9 +36,9 @@ func New[K kad.Key[K]](self K, cfg *Config[K]) (*TrieRT[K], error) {
 	return rt, nil
 }
 
-func (rt *TrieRT[K]) apply(cfg *Config[K]) error {
+func (rt *TrieRT[K, N]) apply(cfg *Config[K, N]) error {
 	if cfg == nil {
-		cfg = DefaultConfig[K]()
+		cfg = DefaultConfig[K, N]()
 	}
 
 	rt.keyFilter = cfg.KeyFilter
@@ -45,12 +47,12 @@ func (rt *TrieRT[K]) apply(cfg *Config[K]) error {
 }
 
 // Self returns the local node's Kademlia key.
-func (rt *TrieRT[K]) Self() K {
+func (rt *TrieRT[K, N]) Self() K {
 	return rt.self
 }
 
 // AddNode tries to add a node to the routing table.
-func (rt *TrieRT[K]) AddNode(node kad.NodeID[K]) bool {
+func (rt *TrieRT[K, N]) AddNode(node N) bool {
 	kk := node.Key()
 	if rt.keyFilter != nil && !rt.keyFilter(rt, kk) {
 		return false
@@ -61,18 +63,18 @@ func (rt *TrieRT[K]) AddNode(node kad.NodeID[K]) bool {
 
 // RemoveKey tries to remove a node identified by its Kademlia key from the
 // routing table. It returns true if the key was found to be present in the table and was removed.
-func (rt *TrieRT[K]) RemoveKey(kk K) bool {
+func (rt *TrieRT[K, N]) RemoveKey(kk K) bool {
 	return rt.keys.Remove(kk)
 }
 
 // NearestNodes returns the n closest nodes to a given key.
-func (rt *TrieRT[K]) NearestNodes(target K, n int) []kad.NodeID[K] {
+func (rt *TrieRT[K, N]) NearestNodes(target K, n int) []N {
 	closestEntries := trie.Closest(rt.keys, target, n)
 	if len(closestEntries) == 0 {
-		return []kad.NodeID[K]{}
+		return []N{}
 	}
 
-	nodes := make([]kad.NodeID[K], 0, len(closestEntries))
+	nodes := make([]N, 0, len(closestEntries))
 	for _, c := range closestEntries {
 		nodes = append(nodes, c.Data)
 	}
@@ -80,7 +82,7 @@ func (rt *TrieRT[K]) NearestNodes(target K, n int) []kad.NodeID[K] {
 	return nodes
 }
 
-func (rt *TrieRT[K]) Find(ctx context.Context, kk K) (kad.NodeID[K], error) {
+func (rt *TrieRT[K, N]) Find(ctx context.Context, kk K) (kad.NodeID[K], error) {
 	found, node := trie.Find(rt.keys, kk)
 	if found {
 		return node, nil
@@ -90,17 +92,17 @@ func (rt *TrieRT[K]) Find(ctx context.Context, kk K) (kad.NodeID[K], error) {
 }
 
 // Size returns the number of peers contained in the table.
-func (rt *TrieRT[K]) Size() int {
+func (rt *TrieRT[K, N]) Size() int {
 	return rt.keys.Size()
 }
 
 // Cpl returns the longest common prefix length the supplied key shares with the table's key.
-func (rt *TrieRT[K]) Cpl(kk K) int {
+func (rt *TrieRT[K, N]) Cpl(kk K) int {
 	return rt.self.CommonPrefixLength(kk)
 }
 
 // CplSize returns the number of peers in the table whose longest common prefix with the table's key is of length cpl.
-func (rt *TrieRT[K]) CplSize(cpl int) int {
+func (rt *TrieRT[K, N]) CplSize(cpl int) int {
 	n, err := countCpl(rt.keys, rt.self, cpl, 0)
 	if err != nil {
 		return 0
@@ -108,7 +110,7 @@ func (rt *TrieRT[K]) CplSize(cpl int) int {
 	return n
 }
 
-func countCpl[K kad.Key[K]](t *trie.Trie[K, kad.NodeID[K]], kk K, cpl int, depth int) (int, error) {
+func countCpl[K kad.Key[K], N kad.NodeID[K]](t *trie.Trie[K, N], kk K, cpl int, depth int) (int, error) {
 	// special cases for very small tables where keys may be placed higher in the trie due to low population
 	if t.IsLeaf() {
 		if !t.HasKey() {

--- a/routing/triert/table.go
+++ b/routing/triert/table.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 
 	"github.com/plprobelab/go-kademlia/internal/kadtest"
-
-	"github.com/plprobelab/go-kademlia/key"
-
 	"github.com/plprobelab/go-kademlia/kad"
+	"github.com/plprobelab/go-kademlia/key"
 	"github.com/plprobelab/go-kademlia/key/trie"
 )
 

--- a/routing/triert/table_test.go
+++ b/routing/triert/table_test.go
@@ -26,22 +26,23 @@ var (
 	key10 = kadtest.RandomKeyWithPrefix("001000")
 	key11 = kadtest.RandomKeyWithPrefix("001100")
 
-	node1  = NewNode("QmPeer1", key1)
-	node2  = NewNode("QmPeer2", key2)
-	node3  = NewNode("QmPeer3", key3)
-	node4  = NewNode("QmPeer4", key4)
-	node5  = NewNode("QmPeer5", key5)
-	node6  = NewNode("QmPeer6", key6)
-	node7  = NewNode("QmPeer7", key7)
-	node8  = NewNode("QmPeer8", key8)
-	node9  = NewNode("QmPeer9", key9)
-	node10 = NewNode("QmPeer10", key10)
-	node11 = NewNode("QmPeer11", key11)
+	node0  = newNode("QmPeer0", key0)
+	node1  = newNode("QmPeer1", key1)
+	node2  = newNode("QmPeer2", key2)
+	node3  = newNode("QmPeer3", key3)
+	node4  = newNode("QmPeer4", key4)
+	node5  = newNode("QmPeer5", key5)
+	node6  = newNode("QmPeer6", key6)
+	node7  = newNode("QmPeer7", key7)
+	node8  = newNode("QmPeer8", key8)
+	node9  = newNode("QmPeer9", key9)
+	node10 = newNode("QmPeer10", key10)
+	node11 = newNode("QmPeer11", key11)
 )
 
 func TestAddPeer(t *testing.T) {
 	t.Run("one", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		success := rt.AddNode(node1)
 		require.True(t, success)
@@ -49,7 +50,7 @@ func TestAddPeer(t *testing.T) {
 	})
 
 	t.Run("ignore duplicate", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		success := rt.AddNode(node1)
 		require.True(t, success)
@@ -61,7 +62,7 @@ func TestAddPeer(t *testing.T) {
 	})
 
 	t.Run("many", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		success := rt.AddNode(node1)
 		require.True(t, success)
@@ -92,7 +93,7 @@ func TestAddPeer(t *testing.T) {
 }
 
 func TestRemovePeer(t *testing.T) {
-	rt, err := New(key0, nil)
+	rt, err := New[key.Key32](node0, nil)
 	require.NoError(t, err)
 	success := rt.AddNode(node1)
 	require.NoError(t, err)
@@ -111,7 +112,7 @@ func TestRemovePeer(t *testing.T) {
 
 func TestFindPeer(t *testing.T) {
 	t.Run("known peer", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		success := rt.AddNode(node1)
 		require.True(t, success)
@@ -123,7 +124,7 @@ func TestFindPeer(t *testing.T) {
 	})
 
 	t.Run("unknown peer", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		got, err := rt.Find(context.Background(), key2)
 		require.NoError(t, err)
@@ -131,7 +132,7 @@ func TestFindPeer(t *testing.T) {
 	})
 
 	t.Run("removed peer", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		success := rt.AddNode(node1)
 		require.True(t, success)
@@ -151,7 +152,7 @@ func TestFindPeer(t *testing.T) {
 }
 
 func TestNearestPeers(t *testing.T) {
-	rt, err := New(key0, nil)
+	rt, err := New[key.Key32](node0, nil)
 	require.NoError(t, err)
 	rt.AddNode(node1)
 	rt.AddNode(node2)
@@ -169,7 +170,7 @@ func TestNearestPeers(t *testing.T) {
 	peers := rt.NearestNodes(key0, 5)
 	require.Equal(t, 5, len(peers))
 
-	expectedOrder := []kad.NodeID[key.Key32]{node9, node8, node7, node10, node11}
+	expectedOrder := []node[key.Key32]{node9, node8, node7, node10, node11}
 	require.Equal(t, expectedOrder, peers)
 
 	peers = rt.NearestNodes(node11.Key(), 2)
@@ -179,7 +180,7 @@ func TestNearestPeers(t *testing.T) {
 
 func TestCplSize(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, rt.Size())
 		require.Equal(t, 0, rt.CplSize(1))
@@ -189,13 +190,13 @@ func TestCplSize(t *testing.T) {
 	})
 
 	t.Run("cpl 1", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 
-		success := rt.AddNode(NewNode("cpl1a", kadtest.RandomKeyWithPrefix("01")))
+		success := rt.AddNode(newNode("cpl1a", kadtest.RandomKeyWithPrefix("01")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl1b", kadtest.RandomKeyWithPrefix("01")))
+		success = rt.AddNode(newNode("cpl1b", kadtest.RandomKeyWithPrefix("01")))
 		require.NoError(t, err)
 		require.True(t, success)
 		require.Equal(t, 2, rt.Size())
@@ -206,13 +207,13 @@ func TestCplSize(t *testing.T) {
 	})
 
 	t.Run("cpl 2", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 
-		success := rt.AddNode(NewNode("cpl2a", kadtest.RandomKeyWithPrefix("001")))
+		success := rt.AddNode(newNode("cpl2a", kadtest.RandomKeyWithPrefix("001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl2b", kadtest.RandomKeyWithPrefix("001")))
+		success = rt.AddNode(newNode("cpl2b", kadtest.RandomKeyWithPrefix("001")))
 		require.NoError(t, err)
 		require.True(t, success)
 
@@ -224,19 +225,19 @@ func TestCplSize(t *testing.T) {
 	})
 
 	t.Run("cpl 3", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 
-		success := rt.AddNode(NewNode("cpl3a", kadtest.RandomKeyWithPrefix("0001")))
+		success := rt.AddNode(newNode("cpl3a", kadtest.RandomKeyWithPrefix("0001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl3b", kadtest.RandomKeyWithPrefix("0001")))
+		success = rt.AddNode(newNode("cpl3b", kadtest.RandomKeyWithPrefix("0001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl3c", kadtest.RandomKeyWithPrefix("0001")))
+		success = rt.AddNode(newNode("cpl3c", kadtest.RandomKeyWithPrefix("0001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl3d", kadtest.RandomKeyWithPrefix("0001")))
+		success = rt.AddNode(newNode("cpl3d", kadtest.RandomKeyWithPrefix("0001")))
 		require.NoError(t, err)
 		require.True(t, success)
 
@@ -248,33 +249,33 @@ func TestCplSize(t *testing.T) {
 	})
 
 	t.Run("cpl mixed", func(t *testing.T) {
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](node0, nil)
 		require.NoError(t, err)
 
-		success := rt.AddNode(NewNode("cpl1a", kadtest.RandomKeyWithPrefix("01")))
+		success := rt.AddNode(newNode("cpl1a", kadtest.RandomKeyWithPrefix("01")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl1b", kadtest.RandomKeyWithPrefix("01")))
-		require.NoError(t, err)
-		require.True(t, success)
-
-		success = rt.AddNode(NewNode("cpl2a", kadtest.RandomKeyWithPrefix("001")))
-		require.NoError(t, err)
-		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl2b", kadtest.RandomKeyWithPrefix("001")))
+		success = rt.AddNode(newNode("cpl1b", kadtest.RandomKeyWithPrefix("01")))
 		require.NoError(t, err)
 		require.True(t, success)
 
-		success = rt.AddNode(NewNode("cpl3a", kadtest.RandomKeyWithPrefix("0001")))
+		success = rt.AddNode(newNode("cpl2a", kadtest.RandomKeyWithPrefix("001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl3b", kadtest.RandomKeyWithPrefix("0001")))
+		success = rt.AddNode(newNode("cpl2b", kadtest.RandomKeyWithPrefix("001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl3c", kadtest.RandomKeyWithPrefix("0001")))
+
+		success = rt.AddNode(newNode("cpl3a", kadtest.RandomKeyWithPrefix("0001")))
 		require.NoError(t, err)
 		require.True(t, success)
-		success = rt.AddNode(NewNode("cpl3d", kadtest.RandomKeyWithPrefix("0001")))
+		success = rt.AddNode(newNode("cpl3b", kadtest.RandomKeyWithPrefix("0001")))
+		require.NoError(t, err)
+		require.True(t, success)
+		success = rt.AddNode(newNode("cpl3c", kadtest.RandomKeyWithPrefix("0001")))
+		require.NoError(t, err)
+		require.True(t, success)
+		success = rt.AddNode(newNode("cpl3d", kadtest.RandomKeyWithPrefix("0001")))
 		require.NoError(t, err)
 		require.True(t, success)
 
@@ -287,11 +288,11 @@ func TestCplSize(t *testing.T) {
 
 func TestKeyFilter(t *testing.T) {
 	ctx := context.Background()
-	cfg := DefaultConfig[key.Key32]()
-	cfg.KeyFilter = func(rt *TrieRT[key.Key32], kk key.Key32) bool {
+	cfg := DefaultConfig[key.Key32, node[key.Key32]]()
+	cfg.KeyFilter = func(rt *TrieRT[key.Key32, node[key.Key32]], kk key.Key32) bool {
 		return !key.Equal(kk, key2) // don't allow key2 to be added
 	}
-	rt, err := New(key0, cfg)
+	rt, err := New[key.Key32](node0, cfg)
 	require.NoError(t, err)
 
 	// can't add key2
@@ -346,14 +347,14 @@ func BenchmarkChurn(b *testing.B) {
 
 func benchmarkBuildTable(n int) func(b *testing.B) {
 	return func(b *testing.B) {
-		nodes := make([]kad.NodeID[key.Key32], n)
+		nodes := make([]*kadtest.ID[key.Key32], n)
 		for i := 0; i < n; i++ {
 			nodes[i] = kadtest.NewID(kadtest.RandomKey())
 		}
 		b.ResetTimer()
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			rt, err := New(key0, nil)
+			rt, err := New[key.Key32](kadtest.NewID(key0), nil)
 			if err != nil {
 				b.Fatalf("unexpected error creating table: %v", err)
 			}
@@ -371,7 +372,7 @@ func benchmarkFindPositive(n int) func(b *testing.B) {
 		for i := 0; i < n; i++ {
 			keys[i] = kadtest.RandomKey()
 		}
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](kadtest.NewID(key0), nil)
 		if err != nil {
 			b.Fatalf("unexpected error creating table: %v", err)
 		}
@@ -392,7 +393,7 @@ func benchmarkFindNegative(n int) func(b *testing.B) {
 		for i := 0; i < n; i++ {
 			keys[i] = kadtest.RandomKey()
 		}
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](kadtest.NewID(key0), nil)
 		if err != nil {
 			b.Fatalf("unexpected error creating table: %v", err)
 		}
@@ -423,7 +424,7 @@ func benchmarkNearestPeers(n int) func(b *testing.B) {
 		for i := 0; i < n; i++ {
 			keys[i] = kadtest.RandomKey()
 		}
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](kadtest.NewID(key0), nil)
 		if err != nil {
 			b.Fatalf("unexpected error creating table: %v", err)
 		}
@@ -440,11 +441,11 @@ func benchmarkNearestPeers(n int) func(b *testing.B) {
 
 func benchmarkChurn(n int) func(b *testing.B) {
 	return func(b *testing.B) {
-		universe := make([]kad.NodeID[key.Key32], n)
+		universe := make([]*kadtest.ID[key.Key32], n)
 		for i := 0; i < n; i++ {
 			universe[i] = kadtest.NewID(kadtest.RandomKey())
 		}
-		rt, err := New(key0, nil)
+		rt, err := New[key.Key32](kadtest.NewID(key0), nil)
 		if err != nil {
 			b.Fatalf("unexpected error creating table: %v", err)
 		}
@@ -470,15 +471,15 @@ func benchmarkChurn(n int) func(b *testing.B) {
 	}
 }
 
-// var _ kad.NodeID = (*node)(nil)
-
 type node[K kad.Key[K]] struct {
 	id  string
 	key K
 }
 
-func NewNode[K kad.Key[K]](id string, k K) *node[K] {
-	return &node[K]{
+var _ kad.NodeID[key.Key32] = (*node[key.Key32])(nil)
+
+func newNode[K kad.Key[K]](id string, k K) node[K] {
+	return node[K]{
 		id:  id,
 		key: k,
 	}
@@ -493,5 +494,5 @@ func (n node[K]) Key() K {
 }
 
 func (n node[K]) NodeID() kad.NodeID[K] {
-	return &n
+	return n
 }

--- a/server/basicserver/basicserver.go
+++ b/server/basicserver/basicserver.go
@@ -18,7 +18,7 @@ import (
 )
 
 type BasicServer[A kad.Address[A]] struct {
-	rt       kad.RoutingTable[key.Key256]
+	rt       kad.RoutingTable[key.Key256, kad.NodeID[key.Key256]]
 	endpoint endpoint.Endpoint[key.Key256, A]
 
 	peerstoreTTL              time.Duration
@@ -27,7 +27,7 @@ type BasicServer[A kad.Address[A]] struct {
 
 // var _ server.Server = (*BasicServer)(nil)
 
-func NewBasicServer[A kad.Address[A]](rt kad.RoutingTable[key.Key256], endpoint endpoint.Endpoint[key.Key256, A],
+func NewBasicServer[A kad.Address[A]](rt kad.RoutingTable[key.Key256, kad.NodeID[key.Key256]], endpoint endpoint.Endpoint[key.Key256, A],
 	options ...Option,
 ) *BasicServer[A] {
 	var cfg Config

--- a/server/basicserver/basicserver_test.go
+++ b/server/basicserver/basicserver_test.go
@@ -49,7 +49,7 @@ func TestSimMessageHandling(t *testing.T) {
 	router := sim.NewRouter[key.Key256, net.IP]()
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := sim.NewEndpoint[key.Key256, net.IP](self.ID(), sched, router)
-	rt := simplert.New(self.ID().Key(), 2)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](self.ID(), 2)
 
 	// add peers to routing table and peerstore
 	for _, p := range kadRemotePeers {
@@ -133,7 +133,7 @@ func TestInvalidSimRequests(t *testing.T) {
 	// create a valid server
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := sim.NewEndpoint[key.Key256, net.IP](self.ID(), sched, router)
-	rt := simplert.New(self.ID().Key(), 2)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](self.ID(), 2)
 
 	// add peers to routing table and peerstore
 	for _, p := range kadRemotePeers {
@@ -178,7 +178,7 @@ func TestSimRequestNoNetworkAddress(t *testing.T) {
 	// create a valid server
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := sim.NewEndpoint(self.ID(), sched, router)
-	rt := simplert.New(self.ID().Key(), 2)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](self.ID(), 2)
 
 	parsed, err := peer.Decode("1EooooPEER")
 	require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestInvalidIpfsv1Requests(t *testing.T) {
 	self := libp2p.NewPeerID(selfPid)
 
 	invalidEP := &invalidEndpoint[key.Key256, multiaddr.Multiaddr]{}
-	rt := simplert.New(self.Key(), 4)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](self, 4)
 
 	nPeers := 6
 	peerids := make([]kad.NodeID[key.Key256], nPeers)
@@ -326,7 +326,7 @@ func TestIPFSv1Handling(t *testing.T) {
 	router := sim.NewRouter[key.Key256, multiaddr.Multiaddr]()
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := sim.NewEndpoint[key.Key256, multiaddr.Multiaddr](self.NodeID(), sched, router)
-	rt := simplert.New(self.Key(), 4)
+	rt := simplert.New[key.Key256, kad.NodeID[key.Key256]](self, 4)
 
 	nPeers := 6
 	peerids := make([]kad.NodeID[key.Key256], nPeers)

--- a/sim/endpoint_test.go
+++ b/sim/endpoint_test.go
@@ -94,7 +94,7 @@ func TestEndpoint(t *testing.T) {
 
 	sched0 := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint0 := NewEndpoint[key.Key256, net.IP](node0.ID(), sched0, router)
-	rt0 := simplert.New(node0.ID().Key(), 2)
+	rt0 := simplert.New[key.Key256, kad.NodeID[key.Key256]](node0.ID(), 2)
 	serv0 := NewServer[key.Key256, net.IP](rt0, fakeEndpoint0, DefaultServerConfig())
 	err = fakeEndpoint0.AddRequestHandler(protoID, nil, serv0.HandleRequest)
 	require.NoError(t, err)

--- a/sim/server.go
+++ b/sim/server.go
@@ -14,14 +14,14 @@ import (
 )
 
 type Server[K kad.Key[K], A kad.Address[A]] struct {
-	rt       kad.RoutingTable[K]
+	rt       kad.RoutingTable[K, kad.NodeID[K]]
 	endpoint endpoint.Endpoint[K, A]
 
 	peerstoreTTL              time.Duration
 	numberOfCloserPeersToSend int
 }
 
-func NewServer[K kad.Key[K], A kad.Address[A]](rt kad.RoutingTable[K], endpoint endpoint.Endpoint[K, A], cfg *ServerConfig) *Server[K, A] {
+func NewServer[K kad.Key[K], A kad.Address[A]](rt kad.RoutingTable[K, kad.NodeID[K]], endpoint endpoint.Endpoint[K, A], cfg *ServerConfig) *Server[K, A] {
 	if cfg == nil {
 		cfg = DefaultServerConfig()
 	}

--- a/sim/server_test.go
+++ b/sim/server_test.go
@@ -42,7 +42,7 @@ func TestMessageHandling(t *testing.T) {
 	router := NewRouter[key.Key8, net.IP]()
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := NewEndpoint[key.Key8, net.IP](self.ID(), sched, router)
-	rt := simplert.New(self.ID().Key(), 2)
+	rt := simplert.New[key.Key8, kad.NodeID[key.Key8]](self.ID(), 2)
 
 	// add peers to routing table and peerstore
 	for _, p := range kadRemotePeers {
@@ -129,7 +129,7 @@ func TestInvalidSimRequests(t *testing.T) {
 	// create a valid server
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := NewEndpoint[key.Key8, net.IP](self.ID(), sched, router)
-	rt := simplert.New(self.ID().Key(), 2)
+	rt := simplert.New[key.Key8, kad.NodeID[key.Key8]](self.ID(), 2)
 
 	// add peers to routing table and peerstore
 	for _, p := range kadRemotePeers {
@@ -170,7 +170,7 @@ func TestRequestNoNetworkAddress(t *testing.T) {
 	// create a valid server
 	sched := simplescheduler.NewSimpleScheduler(clk)
 	fakeEndpoint := NewEndpoint[key.Key8, net.IP](self.ID(), sched, router)
-	rt := simplert.New(self.ID().Key(), 2)
+	rt := simplert.New[key.Key8, kad.NodeID[key.Key8]](self.ID(), 2)
 
 	node := kadtest.NewID(key.Key8(0xf6))
 


### PR DESCRIPTION
**Changelog:**

- Added `NodeID[K]` type parameter to routing table interface
- Fixed tests for simplert and triert

**ToDo:**

- [x] it doesn't plug into the coordinator yet