### PR TITLE
Add protocol interfaces

### DIFF
--- a/kad/kad.go
+++ b/kad/kad.go
@@ -140,6 +140,8 @@ type RoutingProtocol[K Key[K], N NodeID[K], A Address[A]] interface {
 }
 
 type RecordProtocol[K Key[K], N NodeID[K]] interface {
-	Get(ctx context.Context, to N, target K) ([]any, []N, error)
-	Put(ctx context.Context, to N, record any) error
+	Get(ctx context.Context, to N, target K) ([]Record, []N, error)
+	Put(ctx context.Context, to N, record Record) error
 }
+
+type Record any

--- a/kad/kad.go
+++ b/kad/kad.go
@@ -1,5 +1,9 @@
 package kad
 
+import (
+	"context"
+)
+
 // Key is the interface all Kademlia key types support.
 //
 // A Kademlia key is defined as a bit string of arbitrary size. In practice, different Kademlia implementations use
@@ -128,4 +132,14 @@ type Response[K Key[K], A Address[A]] interface {
 	Message
 
 	CloserNodes() []NodeInfo[K, A]
+}
+
+type RoutingProtocol[K Key[K], N NodeID[K], A Address[A]] interface {
+	FindNode(ctx context.Context, to N, target K) (NodeInfo[K, A], []N, error)
+	Ping(ctx context.Context, to N) error
+}
+
+type RecordProtocol[K Key[K], N NodeID[K]] interface {
+	Get(ctx context.Context, to N, target K) ([]any, []N, error)
+	Put(ctx context.Context, to N, record any) error
 }


### PR DESCRIPTION
**Changelog:**

- adds the routing and record protocol interfaces


I removed the `Record` interface (which was an empty interface anyways) and replaced it with `any`. Can revert any time if we needed to.