### PR TITLE
Fix race in coordinator test

### DIFF
--- a/query/simplequery/query_test.go
+++ b/query/simplequery/query_test.go
@@ -704,11 +704,7 @@ func TestCornerCases(t *testing.T) {
 		q.requestError(ctx, node1.ID(), errors.New(""))
 	}))
 
-	// create simulator
-	s := sim.NewLiteSimulator(clk)
-	sim.AddSchedulers(s, sched0)
-	// run simulation
-	s.Run(ctx)
+	sched0.RunOne(ctx)
 
 	require.True(t, q.done)
 }

--- a/sim/simulator.go
+++ b/sim/simulator.go
@@ -75,6 +75,11 @@ func (s *LiteSimulator) Run(ctx context.Context) {
 	}
 
 	for len(nextActions) > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		// find the time of the next action to be run
 		minTime := event.MaxTime
 		for _, t := range nextActions {
@@ -101,6 +106,11 @@ func (s *LiteSimulator) Run(ctx context.Context) {
 		}
 
 		for len(upNext) > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			ongoing := make([]int, len(upNext))
 			copy(ongoing, upNext)
 


### PR DESCRIPTION
Test was reading from the routing table while the simulator was running in a separate goroutine. Also fixed simulator responding to context cancelation.